### PR TITLE
Added Scan management logic to perform Audit scans using Jfrog Cli 

### DIFF
--- a/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/PreferenceConstants.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/PreferenceConstants.java
@@ -2,7 +2,6 @@ package com.jfrog.ide.eclipse.configuration;
 
 import java.util.HashMap;
 import java.util.Map;
-
 /**
  * Constant definitions for plug-in preferences
  * 

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/PreferenceConstants.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/PreferenceConstants.java
@@ -1,5 +1,8 @@
 package com.jfrog.ide.eclipse.configuration;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Constant definitions for plug-in preferences
  * 
@@ -12,7 +15,7 @@ public class PreferenceConstants {
 	public static final String XRAY_URL = "URL";
 	public static final String XRAY_USERNAME = "Username";
 	public static final String XRAY_PASSWORD = "Password";
-	public static final String DEBUG_LOGS = "checkboxPreference";
+	public static final String DEBUG_LOGS = "DebugLogs";
 	
 	// Connection constants
 	public static final int CONNECTION_TIMEOUT_MILLISECONDS = 300 * 1000;
@@ -21,4 +24,13 @@ public class PreferenceConstants {
 	// Eclipse Buildship plugins
 	public static final String GRADLE_PLUGIN_QUALIFIER = "org.eclipse.buildship.core";
 	public static final String GRADLE_DISTRIBUTION = "gradle.distribution";
+	
+	
+	public static Map<String, String> getCliDebugLogsEnvVars(){
+		Map<String, String> envVars = new HashMap<>();
+		envVars.put("JFROG_CLI_LOG_LEVEL", "DEBUG");
+		envVars.put("CI", "true");
+		
+		return envVars;
+	}
 }

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/PreferenceConstants.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/PreferenceConstants.java
@@ -12,6 +12,7 @@ public class PreferenceConstants {
 	public static final String XRAY_URL = "URL";
 	public static final String XRAY_USERNAME = "Username";
 	public static final String XRAY_PASSWORD = "Password";
+	public static final String DEBUG_LOGS = "checkboxPreference";
 	
 	// Connection constants
 	public static final int CONNECTION_TIMEOUT_MILLISECONDS = 300 * 1000;

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/XrayGlobalConfiguration.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/XrayGlobalConfiguration.java
@@ -76,15 +76,15 @@ public class XrayGlobalConfiguration extends FieldEditorPreferencePage implement
 	    // Schedule the CliJob to execute the runnable
 	    CliJob.doSchedule("Setup Server Configuration", runnable);
 		
-		boolean doQuickScan = false;
+		boolean runScan = false;
 		ComponentDetails[] componentsDetails = { ComponentIssueDetails.getInstance()};
 		for (ComponentDetails componentsDetail : componentsDetails) {
 			if (componentsDetail != null) {
 				componentsDetail.credentialsSet();
-				doQuickScan = true;
+				runScan = true;
 			}
 		}
-		if (doQuickScan) {
+		if (runScan) {
 			ScanManager.getInstance().startScan(getShell().getParent(),
 					getPreferenceStore().getBoolean(PreferenceConstants.DEBUG_LOGS));
 		}

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/XrayGlobalConfiguration.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/XrayGlobalConfiguration.java
@@ -16,12 +16,9 @@ import org.eclipse.ui.dialogs.PreferencesUtil;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
 
 import com.jfrog.ide.eclipse.log.Logger;
-import com.jfrog.ide.eclipse.scan.ScanManager;
 import com.jfrog.ide.eclipse.scheduling.CliJob;
 import com.jfrog.ide.eclipse.ui.ComponentDetails;
 import com.jfrog.ide.eclipse.ui.issues.ComponentIssueDetails;
-import com.jfrog.ide.eclipse.ui.issues.IssuesTree;
-
 /**
  * Panel for configuring Xray URL, username and password.
  * 
@@ -42,7 +39,6 @@ public class XrayGlobalConfiguration extends FieldEditorPreferencePage implement
 		StringFieldEditor passwordEditor = new StringFieldEditor(PreferenceConstants.XRAY_PASSWORD, "Password:",
 				getFieldEditorParent());
 		passwordEditor.getTextControl(getFieldEditorParent()).setEchoChar('*');
-		
 
 		addField(urlEditor);
 		addField(usernameEditor);
@@ -88,7 +84,7 @@ public class XrayGlobalConfiguration extends FieldEditorPreferencePage implement
 	    };
 
 	    // Schedule the CliJob to execute the runnable
-	    CliJob.doSchedule("Setup Server Configuration and Perform Initial Scan", runnableServerConfig);
+	    CliJob.doSchedule("Setup Server Configuration", runnableServerConfig);
 	    
 		ComponentDetails[] componentsDetails = { ComponentIssueDetails.getInstance()};
 		for (ComponentDetails componentsDetail : componentsDetails) {
@@ -96,7 +92,6 @@ public class XrayGlobalConfiguration extends FieldEditorPreferencePage implement
 				componentsDetail.credentialsSet();
 			}
 		}
-		
 		return true;
 	}
 

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/XrayGlobalConfiguration.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/XrayGlobalConfiguration.java
@@ -56,7 +56,7 @@ public class XrayGlobalConfiguration extends FieldEditorPreferencePage implement
 		}
 
 	    // Define the runnable to execute the CLI config command 
-	    ICoreRunnable runnable = monitor -> {
+	    ICoreRunnable runnableServerConfig = monitor -> {
 	        try {
 	            CliDriverWrapper.getInstance().getCliDriver().addCliServerConfig(
 	                XrayServerConfigImpl.getInstance().getXrayUrl(),
@@ -74,19 +74,13 @@ public class XrayGlobalConfiguration extends FieldEditorPreferencePage implement
 	    };
 
 	    // Schedule the CliJob to execute the runnable
-	    CliJob.doSchedule("Setup Server Configuration", runnable);
+	    CliJob.doSchedule("Setup Server Configuration", runnableServerConfig);
 		
-		boolean runScan = false;
 		ComponentDetails[] componentsDetails = { ComponentIssueDetails.getInstance()};
 		for (ComponentDetails componentsDetail : componentsDetails) {
 			if (componentsDetail != null) {
 				componentsDetail.credentialsSet();
-				runScan = true;
 			}
-		}
-		if (runScan) {
-			ScanManager.getInstance().startScan(getShell().getParent(),
-					getPreferenceStore().getBoolean(PreferenceConstants.DEBUG_LOGS));
 		}
 		return true;
 	}

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/XrayGlobalConfiguration.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/XrayGlobalConfiguration.java
@@ -2,6 +2,7 @@ package com.jfrog.ide.eclipse.configuration;
 
 import org.eclipse.core.runtime.ICoreRunnable;
 import org.eclipse.core.runtime.preferences.ConfigurationScope;
+import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.PreferenceDialog;
 import org.eclipse.jface.preference.StringFieldEditor;
@@ -11,6 +12,7 @@ import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
 
+import com.jfrog.ide.eclipse.scan.ScanManager;
 import com.jfrog.ide.eclipse.scheduling.CliJob;
 import com.jfrog.ide.eclipse.ui.ComponentDetails;
 import com.jfrog.ide.eclipse.ui.issues.ComponentIssueDetails;
@@ -40,6 +42,10 @@ public class XrayGlobalConfiguration extends FieldEditorPreferencePage implement
 		addField(usernameEditor);
 		addField(passwordEditor);
 		addField(new TestConnectionButton(urlEditor, usernameEditor, passwordEditor, getFieldEditorParent()));
+		
+		BooleanFieldEditor debugLogsCheckbox = new BooleanFieldEditor(PreferenceConstants.DEBUG_LOGS, "Generate Debug Logs",
+				getFieldEditorParent());
+		addField(debugLogsCheckbox);
 	}
 
 	@Override
@@ -79,7 +85,8 @@ public class XrayGlobalConfiguration extends FieldEditorPreferencePage implement
 			}
 		}
 		if (doQuickScan) {
-			// TODO: run a scan using the ScanManager
+			ScanManager.getInstance().startScan(getShell().getParent(),
+					getPreferenceStore().getBoolean(PreferenceConstants.DEBUG_LOGS));
 		}
 		return true;
 	}

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/XrayServerConfigImpl.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/XrayServerConfigImpl.java
@@ -22,8 +22,6 @@ import com.jfrog.ide.common.configuration.ServerConfig;
  */
 @SuppressWarnings("restriction")
 public class XrayServerConfigImpl implements ServerConfig {
-	// TODO: adjust implementation for configuring server using JfrogCliDriver
-
 	private static XrayServerConfigImpl instance;
 	private IPreferencesService service = Platform.getPreferencesService();
 
@@ -47,6 +45,10 @@ public class XrayServerConfigImpl implements ServerConfig {
 	@Override
 	public String getPassword() {
 		return getValue(PreferenceConstants.XRAY_PASSWORD);
+	}
+	
+	public boolean getIsDebugLogs() {
+		return getValue(PreferenceConstants.DEBUG_LOGS) == "true";
 	}
 
 	private String getValue(String key) {
@@ -110,31 +112,31 @@ public class XrayServerConfigImpl implements ServerConfig {
 
 	@Override
 	public String getAccessToken() {
-		// TODO Auto-generated method stub
+		// This functionality is not yet implemented by the plug-in.
 		return null;
 	}
 
 	@Override
 	public String getExternalResourcesRepo() {
-		// TODO Auto-generated method stub
+		// This functionality is not yet implemented by the plug-in.
 		return null;
 	}
 
 	@Override
 	public PolicyType getPolicyType() {
-		// TODO Auto-generated method stub
+		// This functionality is not yet implemented by the plug-in.
 		return null;
 	}
 
 	@Override
 	public String getProject() {
-		// TODO Auto-generated method stub
+		// This functionality is not yet implemented by the plug-in.
 		return null;
 	}
 
 	@Override
 	public String getWatches() {
-		// TODO Auto-generated method stub
+		// This functionality is not yet implemented by the plug-in.
 		return null;
 	}
 

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/log/Logger.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/log/Logger.java
@@ -12,6 +12,14 @@ public class Logger implements Log {
 	private static Logger instance;
 	private static ProblemsLogger viewLogger;
 	private final String ID = "jfrog-eclipse-plugin";
+	
+	public static final int DEBUG = 1;
+	public static final int INFO = 2;
+	public static final int WARN = 3;
+	public static final int ERROR = 4;
+	
+	//set default log level as INFO
+	private int logLevel = INFO;
 
 	private Logger() {
 		ilog = ResourcesPlugin.getPlugin().getLog();
@@ -23,16 +31,23 @@ public class Logger implements Log {
 		}
 		return instance;
 	}
+	
+	public void setLogLevel(int logLevel) {
+	    this.logLevel = logLevel;
+	}
+
+	public int getLogLevel() {
+	    return logLevel;
+	}
 
 	@Override
 	public void debug(String message) {
-		ilog.log(new Status(Status.OK, ID, "[OK] " + message));
+		log(DEBUG, Status.OK, "[DEBUG] ", message);
 	}
 
 	@Override
 	public void error(String message) {
-		ilog.log(new Status(Status.ERROR, ID, "[ERROR] " + message));
-		logToProblemsLogger(message, Status.ERROR);
+		log(ERROR, Status.ERROR, "[ERROR] ", message);
 	}
 
 	@Override
@@ -43,14 +58,22 @@ public class Logger implements Log {
 
 	@Override
 	public void info(String message) {
-		ilog.log(new Status(Status.INFO, ID, "[INFO] " + message));
+		log(INFO, Status.INFO, "[INFO] ", message);
 	}
 
 	@Override
 	public void warn(String message) {
-		ilog.log(new Status(Status.WARNING, ID, "[WARN] " + message));
-		logToProblemsLogger(message, Status.WARNING);
+		log(WARN, Status.WARNING, "[WARN] ", message);
 	}
+	
+    private void log(int level, int status, String prefix, String message) {
+        if (logLevel <= level) {
+            ilog.log(new Status(status, ID, prefix + message));
+            if (status == Status.WARNING || status == Status.ERROR) {
+                logToProblemsLogger(message, status);
+            }
+        }
+    }
 
 	private void logToProblemsLogger(String message, int status) {
 		if (viewLogger == null) {

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/log/Logger.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/log/Logger.java
@@ -19,7 +19,7 @@ public class Logger implements Log {
 	public static final int ERROR = 4;
 	
 	//set default log level as INFO
-	private int logLevel = INFO;
+	private int minLogLevel = INFO;
 
 	private Logger() {
 		ilog = ResourcesPlugin.getPlugin().getLog();
@@ -33,11 +33,11 @@ public class Logger implements Log {
 	}
 	
 	public void setLogLevel(int logLevel) {
-	    this.logLevel = logLevel;
+	    this.minLogLevel = logLevel;
 	}
 
 	public int getLogLevel() {
-	    return logLevel;
+	    return minLogLevel;
 	}
 
 	@Override
@@ -67,12 +67,13 @@ public class Logger implements Log {
 	}
 	
     private void log(int level, int status, String prefix, String message) {
-        if (logLevel <= level) {
-            ilog.log(new Status(status, ID, prefix + message));
-            if (status == Status.WARNING || status == Status.ERROR) {
-                logToProblemsLogger(message, status);
-            }
-        }
+        if (minLogLevel > level) {
+            return; 
+       }
+       ilog.log(new Status(status, ID, prefix + message));
+       if (status == Status.WARNING || status == Status.ERROR) {
+           logToProblemsLogger(message, status);
+       }
     }
 
 	private void logToProblemsLogger(String message, int status) {

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/scan/ScanCache.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/scan/ScanCache.java
@@ -1,0 +1,41 @@
+package com.jfrog.ide.eclipse.scan;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.jfrog.ide.common.nodes.FileTreeNode;
+
+public class ScanCache {
+	private List<FileTreeNode> scanResults;
+	
+	private static ScanCache instance;
+	
+	private ScanCache() {
+		scanResults = new ArrayList<FileTreeNode>();
+	}
+	
+    public static ScanCache getInstance() {
+        if (instance == null) {
+            synchronized (ScanCache.class) {
+                if (instance == null) {
+                    instance = new ScanCache();
+                }
+            }
+        }
+        return instance;
+    }
+    
+    public List<FileTreeNode> getScanResults() {
+    	return scanResults;
+    }
+    
+    public void updateScanResults(List<FileTreeNode> results) {
+    	if (results != null) {
+    		scanResults.addAll(results);
+    	}
+    }
+    
+    public void resetCache() {
+    	scanResults = new ArrayList<FileTreeNode>();
+    }
+}

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/scan/ScanManager.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/scan/ScanManager.java
@@ -1,65 +1,95 @@
 package com.jfrog.ide.eclipse.scan;
 
-import java.io.IOException;
-import java.nio.file.Files;
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.ICoreRunnable;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.swt.widgets.Composite;
-import org.jfrog.build.extractor.scan.DependencyTree;
+import org.jfrog.build.extractor.executor.CommandResults;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.jfrog.ide.common.configuration.JfrogCliDriver;
-import com.jfrog.ide.common.filter.FilterManager;
-import com.jfrog.ide.common.log.ProgressIndicator;
-import com.jfrog.ide.common.scan.ComponentPrefix;
-import com.jfrog.ide.eclipse.configuration.XrayServerConfigImpl;
+import com.jfrog.ide.common.parse.SarifParser;
+import com.jfrog.ide.eclipse.configuration.CliDriverWrapper;
 import com.jfrog.ide.eclipse.log.Logger;
-import com.jfrog.ide.eclipse.log.ProgressIndicatorImpl;
 import com.jfrog.ide.eclipse.scheduling.CliJob;
-import com.jfrog.ide.eclipse.ui.FilterManagerSingleton;
+import com.jfrog.ide.eclipse.ui.issues.ComponentIssueDetails;
 import com.jfrog.ide.eclipse.ui.issues.IssuesTree;
-import com.jfrog.ide.eclipse.utils.ProjectsMap;
-import com.jfrog.xray.client.services.summary.Components;
 import org.jfrog.build.api.util.Log;
 
 /**
  * @author yahavi
  */
-public abstract class ScanManager {
-
+public class ScanManager {
 	static final Path HOME_PATH = Paths.get(System.getProperty("user.home"), ".jfrog-eclipse-plugin");
+	private static ScanManager instance;
 	private IProgressMonitor monitor;
-	IProject project;
-	Log log;
-	JfrogCliDriver cliDriver;
+	private IWorkspace iworkspace;
+	private IProject[] projects;
+	private Log log;
+	private JfrogCliDriver cliDriver;
+	private SarifParser sarifParser;
+	private AtomicBoolean scanInProgress = new AtomicBoolean(false);
+	private AtomicBoolean cancellationRequested = new AtomicBoolean(false);
 	
-	ScanManager(IProject project, ComponentPrefix prefix) throws IOException {
-		this.project = project;
-		Files.createDirectories(HOME_PATH);
-		log = Logger.getInstance();
+	private ScanManager() {
+		this.iworkspace = ResourcesPlugin.getWorkspace();
+		this.projects = iworkspace.getRoot().getProjects();
+		this.log = Logger.getInstance();
+		this.cliDriver = CliDriverWrapper.getInstance().getCliDriver();  
+		this.sarifParser = new SarifParser(log);
+	}
+	
+	public static synchronized ScanManager getInstance(){
+        if (instance == null) {
+            instance = new ScanManager();
+        }
+        return instance;
+	}
+	
+	public void startScan(Composite parent, boolean isDebugLogs) {
+		Map<String, String> auditEnvVars = new HashMap<>();
+		
+		// If scan is in progress - do not perform another scan
+		if (isScanInProgress()) {
+			// TODO: pop up a window message
+			Logger.getInstance().info("Previous scan still running...");
+			return;
+		}
+		
+		scanInProgress.compareAndSet(false, true);
+		resetIssuesView(IssuesTree.getInstance());
+		
+		// refresh projects list
+		this.projects = this.iworkspace.getRoot().getProjects();
+
+		if (isDebugLogs) {
+			auditEnvVars.put("JFROG_CLI_LOG_LEVEL", "DEBUG");
+			auditEnvVars.put("CI", "true");
+		}
+		
+        for (IProject project : projects) {
+        	scanAndUpdateResults(IssuesTree.getInstance(), parent, isDebugLogs, project, auditEnvVars);
+        }
+	}
+	
+	public void checkCanceled() {
+		if (monitor != null && monitor.isCanceled()) {
+			cancellationRequested.set(true);
+			throw new CancellationException("Xray scan was canceled"); // TODO: pop up a message
+		}
 	}
 
-	/**
-	 * Collect and return {@link Components} to be scanned by JFrog Xray.
-	 * Implementation should be project type specific.
-	 * 
-	 * @return
-	 * 
-	 * @throws CoreException
-	 * @throws IOException
-	 * @throws JsonProcessingException
-	 */
-	
-	public IProject getIProject() {
-		return project;
-	}
-	
 	public void setMonitor(IProgressMonitor monitor) {
 		this.monitor = monitor;
 	}
@@ -67,44 +97,98 @@ public abstract class ScanManager {
 	public IProgressMonitor getMonitor(){
 		return monitor;
 	}
+	
+	public boolean isScanInProgress() {
+		return scanInProgress.get();
+	}
 
-	/**
-	 * Schedule a dependency scan.
-	 * 
-	 * @param quickScan - True iff this is a quick scan.
-	 * @param parent    - The parent UI composite. Cancel the scan if the parent is
-	 *                  disposed.
-	 */
-	public void scanAndUpdateResults(boolean quickScan, IssuesTree issuesTree, Composite parent) {
-		CliJob.doSchedule(project.getName(), new ScanRunnable(parent, issuesTree, quickScan));
+	public void scanFinished() {
+		scanInProgress.set(false);
+	}
+
+	public AtomicBoolean getScanInProgress() {
+		return scanInProgress;
+	}
+	
+	private void resetIssuesView(IssuesTree issuesTree) {
+		ComponentIssueDetails.getInstance().recreateComponentDetails();
+		issuesTree.reset();
 	}
 
 	/**
-	 * Start a dependency scan.
+	 * Schedule an audit scan.
+	 * 
+	 * @param issuesTree - The issues tree object to present the issues found by the scan.
+	 * @param parent    - The parent UI composite. Cancel the scan if the parent is
+	 *                  disposed.
+	 * @param isDebugLogs - If set to True, generate debug logs from the audit command.
+	 * @param project - The scanned project object.
+	 * @param envVars = The environment variables for running the audit command.                 
+	 */
+	public void scanAndUpdateResults(IssuesTree issuesTree, Composite parent, boolean isDebugLogs, IProject project, Map<String, String> envVars) {
+		CliJob.doSchedule(String.format("Performing Scan: %s", project.getName()), new ScanRunnable(parent, issuesTree, isDebugLogs, project, envVars)); 
+	}
+
+	/**
+	 * Start an audit scan.
 	 */
 	private class ScanRunnable implements ICoreRunnable {
 		private IssuesTree issuesTree;
-		private boolean quickScan;
 		private Composite parent;
+		private IProject project;
+		private Map<String, String> envVars;
+		private boolean isDebugLogs;
+		
 
-		private ScanRunnable(Composite parent, IssuesTree issuesTree, boolean quickScan) {
+		private ScanRunnable(Composite parent, IssuesTree issuesTree, boolean isDebugLogs, IProject project, Map<String, String> envVars) {
 			this.parent = parent;
 			this.issuesTree = issuesTree;
-			this.quickScan = quickScan;
+			this.project = project;
+			this.envVars = envVars;
+			this.isDebugLogs = isDebugLogs;
 		}
 
 		@Override
 		public void run(IProgressMonitor monitor) throws CoreException {
-			// TODO: implement scan manager using JfrogCliDriver
-		}
+			ScanManager.this.monitor = monitor;
+			if (isDisposed() || monitor.isCanceled()) {
+				return;
+			}
+			
+			log.info(String.format("Performing scan on: %s", project.getName()));
+			
+			try {
+		            if (project.isOpen()) {
+		                IPath projectPath = project.getLocation();
+		    			CommandResults auditResults = cliDriver.runCliAudit(new File(projectPath.toString()), null, "eclipse-plugin", null, envVars);
+		    			if (!auditResults.isOk()) {
+		    				// log the issue to the problems tab
+		    				log.error("Audit scan failed with an error: " + auditResults.getErr());
+		    				return;
+		    			}
+		    			
+		    			log.info("Finished audit scan successfully.\n" + auditResults.getRes());
+		    			if (isDebugLogs) {
+		    				log.debug(auditResults.getErr());
+		    			}
+		    			
+		    			// update scan cache
+		    			log.info("Updating scan cache.");
+		    			ScanCache.getInstance().updateScanResults(sarifParser.parse(auditResults.getRes()));
+		    			
+		    			// TODO: update issues tree
+		            }
 
-		private void setScanResults() {
-			// TODO: re implement using SarifParser
+			} catch (Exception e) {
+				CliDriverWrapper.getInstance().showCliError("An error occurred while performing audit scan", e);
+			} finally {
+				scanFinished();
+			}
 		}
 		
 		private boolean isDisposed() {
 			return parent == null || parent.isDisposed();
 		}
+		
 	}
-
 }

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/scan/ScanManager.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/scan/ScanManager.java
@@ -49,7 +49,7 @@ public class ScanManager {
 		this.sarifParser = new SarifParser(log);
 	}
 	
-	public static synchronized ScanManager getInstance(){
+	public static ScanManager getInstance(){
         if (instance == null) {
             synchronized (ScanManager.class) {
                 if (instance == null) {

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/scan/ScanManager.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/scan/ScanManager.java
@@ -51,7 +51,11 @@ public class ScanManager {
 	
 	public static synchronized ScanManager getInstance(){
         if (instance == null) {
-            instance = new ScanManager();
+            synchronized (ScanManager.class) {
+                if (instance == null) {
+                    instance = new ScanManager();
+                }
+            }
         }
         return instance;
 	}

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/scan/ScanManager.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/scan/ScanManager.java
@@ -67,6 +67,7 @@ public class ScanManager {
 		
 		scanInProgress.compareAndSet(false, true);
 		resetIssuesView(IssuesTree.getInstance());
+		ScanCache.getInstance().resetCache();
 		
 		// refresh projects list
 		projects = iworkspace.getRoot().getProjects();

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/scheduling/CliJobEventListener.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/scheduling/CliJobEventListener.java
@@ -5,15 +5,15 @@ import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 
+import com.jfrog.ide.eclipse.scan.ScanManager;
+
 public class CliJobEventListener extends JobChangeAdapter {
 
 	@Override
 	public void done(IJobChangeEvent event) {
 		Job[] jobs = Job.getJobManager().find(CliJob.FAMILY);
-		// TODO: implement a listener for the audit scan
-//		ScanManagersFactory scanManagersFactory = ScanManagersFactory.getInstance(); 
 		if (ArrayUtils.isEmpty(jobs)) {
-//			scanManagersFactory.scanFinished();
+			ScanManager.getInstance().scanFinished();
 		}
 	}
 }

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/ui/PartControl.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/ui/PartControl.java
@@ -10,7 +10,6 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 
-import com.jfrog.ide.eclipse.configuration.XrayServerConfigImpl;
 import com.jfrog.ide.eclipse.ui.actions.Filter.FilterType;
 import com.jfrog.ide.eclipse.ui.issues.ComponentIssueDetails;
 import com.jfrog.ide.eclipse.ui.issues.IssuesTab;
@@ -30,7 +29,6 @@ public class PartControl {
 		XrayScanToolbar xrayScanToolbar = new XrayScanToolbar(parent);
 
 		createTabs(parent, xrayScanToolbar);
-		doQuickScan(parent);
 	}
 
 	private void createTabs(Composite parent, XrayScanToolbar xrayScanToolbar) {
@@ -43,13 +41,6 @@ public class PartControl {
 				xrayScanToolbar.setFilterType(FilterType.values()[tabFolder.getSelectionIndex()]);
 			}
 		});
-	}
-
-	private void doQuickScan(Composite parent) {
-		if (XrayServerConfigImpl.getInstance().areCredentialsSet()) {
-//			ScanManagersFactory.getInstance().startScan(parent, true);
-			// TODO: run a scan
-		}
 	}
 
 	@PreDestroy

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/ui/actions/Refresh.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/ui/actions/Refresh.java
@@ -4,6 +4,7 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.ToolBar;
 import com.jfrog.ide.eclipse.configuration.XrayServerConfigImpl;
 import com.jfrog.ide.eclipse.log.Logger;
+import com.jfrog.ide.eclipse.scan.ScanManager;
 
 /**
  * Start a new slow scan.
@@ -22,7 +23,7 @@ public class Refresh extends Action {
 			Logger.getInstance().error("Xray server is not configured.");
 			return;
 		}
-//		ScanManagersFactory.getInstance().startScan(getParent(), false);
-		// TODO: run a scan
+		
+		ScanManager.getInstance().startScan(getParent(), XrayServerConfigImpl.getInstance().getIsDebugLogs());
 	}
 }


### PR DESCRIPTION
- Implemented ScanManager to perform an audit scan using the Jfrog CLI.
- In case of multiple projects, the scan will be performed by multiple threads, each one will run a background process for running an audit scan.
- Added functionality to prevent new scans from starting if an existing scan is already in progress, ensuring orderly and non-conflicting scan operations.
- Created the ScanCache class to aggregate scan results and maintain persistence, ensuring that results are consistently displayed in the UI.
- Removed logic of performing a scan when the plugin is loaded.
- Added a checkbox in the settings window to enable the generation of debug logs if necessary.