### PR TITLE
Show SCA and JAS Findings in Issue Details Panel

### DIFF
--- a/bundle/src/main/java/com/jfrog/ide/eclipse/ui/ComponentDetails.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/ui/ComponentDetails.java
@@ -14,9 +14,9 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.forms.events.HyperlinkAdapter;
 import org.eclipse.ui.forms.events.HyperlinkEvent;
 import org.eclipse.ui.forms.widgets.Hyperlink;
-import org.jfrog.build.extractor.scan.DependencyTree;
-import org.jfrog.build.extractor.scan.GeneralInfo;
 
+import com.jfrog.ide.common.nodes.FileIssueNode;
+import com.jfrog.ide.common.nodes.ScaIssueNode;
 import com.jfrog.ide.eclipse.configuration.XrayGlobalConfiguration;
 import com.jfrog.ide.eclipse.configuration.XrayServerConfigImpl;
 
@@ -40,7 +40,7 @@ public abstract class ComponentDetails extends Panel {
 		recreateComponentDetails();
 	}
 
-	public abstract void createDetailsView(DependencyTree node);
+	public abstract void createDetailsView(FileIssueNode node);
 	
 	public void recreateComponentDetails() {
 		if (isDisposed()) {
@@ -85,13 +85,13 @@ public abstract class ComponentDetails extends Panel {
 
 	protected void createComponentsPanel() {
 		createLabel(this, title);
-		scrolledComposite = new ScrolledComposite(this, SWT.BORDER | SWT.V_SCROLL | SWT.FILL);
+		scrolledComposite = new ScrolledComposite(this, SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL | SWT.FILL);
 		scrolledComposite.setBackground(getBackground());
 		setGridLayout(scrolledComposite, 1, false);
 		componentDetailsPanel = new Panel(scrolledComposite);
 		componentDetailsPanel.setBackground(scrolledComposite.getBackground());
 		setGridLayout(componentDetailsPanel, 2, false);
-		UiUtils.createDisabledTextLabel(componentDetailsPanel, "Component information is not available");
+		UiUtils.createDisabledTextLabel(componentDetailsPanel, "Issue information is not available");
 		scrolledComposite.setContent(componentDetailsPanel);
 	}
 
@@ -100,20 +100,18 @@ public abstract class ComponentDetails extends Panel {
 	 * 
 	 * @param node - Extract the component information from this node.
 	 */
-	protected void createCommonInfo(DependencyTree node) {
+	protected void createCommonInfo(FileIssueNode node) {
 		for (Control control : componentDetailsPanel.getChildren()) {
 			control.dispose();
 		}
-		GeneralInfo generalInfo = ObjectUtils.defaultIfNull(node.getGeneralInfo(), new GeneralInfo());
-		if (!StringUtils.equalsIgnoreCase("Npm", generalInfo.getPkgType())) {
-			addSection("Group:", generalInfo.getGroupId());
+		addSection("Title:", node.getTitle());
+		addSection("Reporter:", node.getReporterType().getScannerName());
+		addSection("Severity:", node.getSeverity().getSeverityName());
+		if (!(node instanceof ScaIssueNode)) {
+			addSection("Reason:", node.getReason());
 		}
-
-		addSection("Artifact:", generalInfo.getArtifactId());
-		addSection("Version:", generalInfo.getVersion());
-		addSection("Type:", StringUtils.capitalize(generalInfo.getPkgType()));
-		addSection("Path:", generalInfo.getPath());
-		refreshPanel();
+		addSection("Full Description", node.getFullDescription());
+		addSection("File Path:", node.getFilePath());
 	}
 
 	protected void addSection(String name, String content) {

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/ui/ComponentDetails.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/ui/ComponentDetails.java
@@ -3,7 +3,6 @@ package com.jfrog.ide.eclipse.ui;
 import static com.jfrog.ide.eclipse.ui.UiUtils.createLabel;
 import static com.jfrog.ide.eclipse.ui.UiUtils.setGridLayout;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
@@ -16,7 +15,6 @@ import org.eclipse.ui.forms.events.HyperlinkEvent;
 import org.eclipse.ui.forms.widgets.Hyperlink;
 
 import com.jfrog.ide.common.nodes.FileIssueNode;
-import com.jfrog.ide.common.nodes.ScaIssueNode;
 import com.jfrog.ide.eclipse.configuration.XrayGlobalConfiguration;
 import com.jfrog.ide.eclipse.configuration.XrayServerConfigImpl;
 

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/ui/ComponentDetails.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/ui/ComponentDetails.java
@@ -110,7 +110,7 @@ public abstract class ComponentDetails extends Panel {
 		if (!(node instanceof ScaIssueNode)) {
 			addSection("Reason:", node.getReason());
 		}
-		addSection("Full Description", node.getFullDescription());
+		addSection("Full Description:", node.getFullDescription());
 		addSection("File Path:", node.getFilePath());
 	}
 

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/ui/ComponentDetails.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/ui/ComponentDetails.java
@@ -107,11 +107,10 @@ public abstract class ComponentDetails extends Panel {
 		addSection("Title:", node.getTitle());
 		addSection("Reporter:", node.getReporterType().getScannerName());
 		addSection("Severity:", node.getSeverity().getSeverityName());
-		if (!(node instanceof ScaIssueNode)) {
-			addSection("Reason:", node.getReason());
-		}
 		addSection("Full Description:", node.getFullDescription());
 		addSection("File Path:", node.getFilePath());
+		addSection("Line Snippet:", node.getLineSnippet());
+
 	}
 
 	protected void addSection(String name, String content) {

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/ui/SearchableTree.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/ui/SearchableTree.java
@@ -22,7 +22,6 @@ import org.jfrog.build.extractor.scan.DependencyTree;
 import com.google.common.collect.Lists;
 import com.jfrog.ide.common.nodes.FileIssueNode;
 import com.jfrog.ide.common.nodes.FileTreeNode;
-import com.jfrog.ide.eclipse.utils.ProjectsMap;
 
 /**
  * Base class for the issues tree.
@@ -71,8 +70,11 @@ public abstract class SearchableTree extends FilteredTree {
 				if (event.getSelection().isEmpty()) {
 					return;
 				}
-				FileIssueNode selection = (FileIssueNode) treeViewer.getStructuredSelection().getFirstElement();
-				onClick(selection);
+				Object selectedElement = treeViewer.getStructuredSelection().getFirstElement();
+				if (selectedElement instanceof FileIssueNode) {
+					FileIssueNode issueNode = (FileIssueNode) selectedElement;
+					onClick(issueNode);
+				}
 			}
 		});
 	}

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/ui/SearchableTree.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/ui/SearchableTree.java
@@ -20,6 +20,7 @@ import org.eclipse.ui.dialogs.PatternFilter;
 import org.jfrog.build.extractor.scan.DependencyTree;
 
 import com.google.common.collect.Lists;
+import com.jfrog.ide.common.nodes.FileIssueNode;
 import com.jfrog.ide.common.nodes.FileTreeNode;
 import com.jfrog.ide.eclipse.utils.ProjectsMap;
 
@@ -70,7 +71,7 @@ public abstract class SearchableTree extends FilteredTree {
 				if (event.getSelection().isEmpty()) {
 					return;
 				}
-				DependencyTree selection = (DependencyTree) treeViewer.getStructuredSelection().getFirstElement();
+				FileIssueNode selection = (FileIssueNode) treeViewer.getStructuredSelection().getFirstElement();
 				onClick(selection);
 			}
 		});
@@ -80,7 +81,7 @@ public abstract class SearchableTree extends FilteredTree {
 		this.componentDetails = componentDetails;
 	}
 
-	protected abstract void onClick(DependencyTree selection);
+	protected abstract void onClick(FileIssueNode selection);
 
 	private static PatternFilter createFilter() {
 		PatternFilter patternFilter = new PatternFilter();
@@ -114,7 +115,7 @@ public abstract class SearchableTree extends FilteredTree {
 	public void addScanResults(List<FileTreeNode> results) {
 		scanResults.addAll(results);
 	}
-	
+
 	public void showResultsOnTree() {
 		treeViewer.setInput(scanResults);
 	}

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/ui/UiUtils.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/ui/UiUtils.java
@@ -14,7 +14,7 @@ public class UiUtils {
 
 	public static void setGridLayout(Composite composite, int numColumns, boolean makeColumnsEqualWidth) {
 		composite.setLayout(GridLayoutFactory.fillDefaults().numColumns(numColumns).equalWidth(makeColumnsEqualWidth)
-				.spacing(LayoutConstants.getSpacing().x, 0).create());
+				.spacing(LayoutConstants.getSpacing().x, 3).create());
 		composite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 	}
 

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/ui/UiUtils.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/ui/UiUtils.java
@@ -11,10 +11,11 @@ import org.eclipse.swt.widgets.Label;
  * @author yahavi
  */
 public class UiUtils {
+	private static final int GRID_VERTICAL_SPACER = 3;
 
 	public static void setGridLayout(Composite composite, int numColumns, boolean makeColumnsEqualWidth) {
 		composite.setLayout(GridLayoutFactory.fillDefaults().numColumns(numColumns).equalWidth(makeColumnsEqualWidth)
-				.spacing(LayoutConstants.getSpacing().x, 3).create());
+				.spacing(LayoutConstants.getSpacing().x, GRID_VERTICAL_SPACER).create());
 		composite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 	}
 

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/ui/issues/ComponentIssueDetails.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/ui/issues/ComponentIssueDetails.java
@@ -3,7 +3,6 @@ package com.jfrog.ide.eclipse.ui.issues;
 import org.eclipse.swt.widgets.Composite;
 
 import com.jfrog.ide.common.nodes.FileIssueNode;
-import com.jfrog.ide.common.nodes.SastIssueNode;
 import com.jfrog.ide.common.nodes.ScaIssueNode;
 import com.jfrog.ide.common.parse.Applicability;
 import com.jfrog.ide.eclipse.ui.ComponentDetails;
@@ -49,9 +48,5 @@ public class ComponentIssueDetails extends ComponentDetails {
 		if (instance != null) {
 			instance.dispose();
 		}
-	}
-	
-	private void createScaDetailsView(ScaIssueNode node) {
-		
 	}
 }

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/ui/issues/ComponentIssueDetails.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/ui/issues/ComponentIssueDetails.java
@@ -1,9 +1,11 @@
 package com.jfrog.ide.eclipse.ui.issues;
 
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.swt.widgets.Composite;
-import org.jfrog.build.extractor.scan.DependencyTree;
-import org.jfrog.build.extractor.scan.Issue;
+
+import com.jfrog.ide.common.nodes.FileIssueNode;
+import com.jfrog.ide.common.nodes.SastIssueNode;
+import com.jfrog.ide.common.nodes.ScaIssueNode;
+import com.jfrog.ide.common.parse.Applicability;
 import com.jfrog.ide.eclipse.ui.ComponentDetails;
 
 /**
@@ -23,15 +25,23 @@ public class ComponentIssueDetails extends ComponentDetails {
 	}
 
 	private ComponentIssueDetails(Composite parent) {
-		super(parent, "Component Details");
+		super(parent, "Issue Details");
 	}
 
 	@Override
-	public void createDetailsView(DependencyTree node) {
+	public void createDetailsView(FileIssueNode node) {
 		createCommonInfo(node);
-		Issue topIssue = node.getTopIssue();
-		addSection("Top Issue Severity:", StringUtils.capitalize(topIssue.getSeverity().toString()));
-		addSection("Issues Count:", String.valueOf(node.getIssueCount()));
+		if (node instanceof ScaIssueNode ) {
+			ScaIssueNode scaNode = (ScaIssueNode) node;
+			Applicability applicability = scaNode.getApplicability();
+			addSection("Component Name:", scaNode.getComponentName());
+			addSection("Component Version:", scaNode.getComponentVersion());
+			addSection("Fixed Versions:", scaNode.getFixedVersions());
+			addSection("Applicability:", applicability != null ? applicability.getValue() : "");  
+		} else if (node instanceof SastIssueNode) {
+			SastIssueNode sastNode = (SastIssueNode) node;
+			addSection("Rule ID:", sastNode.getRuleId());
+		}
 		refreshPanel();
 	}
 

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/ui/issues/ComponentIssueDetails.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/ui/issues/ComponentIssueDetails.java
@@ -38,9 +38,9 @@ public class ComponentIssueDetails extends ComponentDetails {
 			addSection("Component Version:", scaNode.getComponentVersion());
 			addSection("Fixed Versions:", scaNode.getFixedVersions());
 			addSection("Applicability:", applicability != null ? applicability.getValue() : "");  
-		} else if (node instanceof SastIssueNode) {
-			SastIssueNode sastNode = (SastIssueNode) node;
-			addSection("Rule ID:", sastNode.getRuleId());
+		} else {
+			addSection("Location:", "row: " + node.getRowStart() + " col: " + node.getColStart());
+			addSection("Reason:", node.getReason());
 		}
 		refreshPanel();
 	}
@@ -49,5 +49,9 @@ public class ComponentIssueDetails extends ComponentDetails {
 		if (instance != null) {
 			instance.dispose();
 		}
+	}
+	
+	private void createScaDetailsView(ScaIssueNode node) {
+		
 	}
 }

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/ui/issues/IssuesTab.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/ui/issues/IssuesTab.java
@@ -24,17 +24,15 @@ public class IssuesTab {
 		// Right
 		SashForm verticalDivision = new SashForm(horizontalDivision, SWT.VERTICAL);
 		ComponentDetails componentDetails = ComponentIssueDetails.createComponentIssueDetails(verticalDivision);
-		ComponentIssueTable componentIssueTable = new ComponentIssueTable(verticalDivision);
 
-		registerTreeListeners(componentDetails, componentIssueTable);
+		registerTreeListeners(componentDetails);
 		horizontalDivision.setWeights(new int[] { 1, 4 });
 		parent.setSelection(tab);
 		tab.setControl(horizontalDivision);
 	}
 
-	private void registerTreeListeners(ComponentDetails componentDetails, ComponentIssueTable componentIssueTable) {
+	private void registerTreeListeners(ComponentDetails componentDetails) {
 		IssuesTree issuesTree = IssuesTree.getInstance();
 		issuesTree.setComponentDetails(componentDetails);
-		issuesTree.setComponentIssueTable(componentIssueTable);
 	}
 }

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/ui/issues/IssuesTree.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/ui/issues/IssuesTree.java
@@ -38,7 +38,6 @@ public class IssuesTree extends SearchableTree {
 
 	@Override
 	public void applyFiltersForAllProjects() {
-		treeViewer.setInput(scanResults);
 	}
 
 	@Override

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/ui/issues/IssuesTree.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/ui/issues/IssuesTree.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import org.eclipse.jface.viewers.TreeViewerColumn;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
-import org.jfrog.build.extractor.scan.DependencyTree;
 
 import com.google.common.collect.Lists;
 import com.jfrog.ide.common.nodes.FileTreeNode;
@@ -17,7 +16,6 @@ import com.jfrog.ide.eclipse.ui.SearchableTree;
 public class IssuesTree extends SearchableTree {
 
 	private static IssuesTree instance;
-	private ComponentIssueTable componentIssueTable;
 	private TreeViewerColumn issuesCountColumn;
 
 	public static void createIssuesTree(Composite parent) {
@@ -34,23 +32,18 @@ public class IssuesTree extends SearchableTree {
 	}
 
 	@Override
-	protected void onClick(DependencyTree selection) {
+	protected void onClick(FileIssueNode selection) {
 		componentDetails.createDetailsView(selection);
-		componentIssueTable.updateIssuesTable(getSelectedNodes());
-	}
-
-	public void setComponentIssueTable(ComponentIssueTable componentIssueTable) {
-		this.componentIssueTable = componentIssueTable;
 	}
 
 	@Override
 	public void applyFiltersForAllProjects() {
+		treeViewer.setInput(scanResults);
 	}
 
 	@Override
 	public void reset() {
 		super.reset();
-		componentIssueTable.updateIssuesTable(Lists.newArrayList());
 		issuesCountColumn.getColumn().setText("Issues");
 		treeViewer.setInput(new ArrayList<FileTreeNode>());
 	}

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/ui/issues/IssuesTree.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/ui/issues/IssuesTree.java
@@ -6,7 +6,7 @@ import org.eclipse.jface.viewers.TreeViewerColumn;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 
-import com.google.common.collect.Lists;
+import com.jfrog.ide.common.nodes.FileIssueNode;
 import com.jfrog.ide.common.nodes.FileTreeNode;
 import com.jfrog.ide.eclipse.ui.SearchableTree;
 


### PR DESCRIPTION
- Modified the issue details panel to display both JAS and SCA findings.
- Removed the component issue table, as it is now redundant due to the new issue tree structure that aggregates security findings by files.