### PR TITLE
Fix false error msg in server config

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -27,7 +27,7 @@
 	</repositories>
 
 	<properties>
-		<ide-plugins-common-version>2.4.3</ide-plugins-common-version>
+		<ide-plugins-common-version>2.4.4</ide-plugins-common-version>
 	</properties>
 
 	<build>

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/CliDriverWrapper.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/CliDriverWrapper.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
+
 import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
@@ -30,7 +32,7 @@ public class CliDriverWrapper {
             showCliError("An error occurred while creating the JFrog Eclipse plugin directory:",e);
         }
         // Initialize the cliDriver and download CLI if needed
-        this.cliDriver = new JfrogCliDriver(null, HOME_PATH.toString(), Logger.getInstance());
+        this.cliDriver = new JfrogCliDriver(new HashMap<String, String>(), HOME_PATH.toString(), Logger.getInstance());
         try {
             this.cliDriver.downloadCliIfNeeded(HOME_PATH.toString(), CLI_VERSION);
         } catch (IOException e) {

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/XrayGlobalConfiguration.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/XrayGlobalConfiguration.java
@@ -81,10 +81,8 @@ public class XrayGlobalConfiguration extends FieldEditorPreferencePage implement
 	                CliDriverWrapper.HOME_PATH.toFile(),
 	                configEnv
 	            );
-        		// log an error in case that the config command returned output not in debug log level
-	            if (!configResults.getErr().isBlank() && !XrayServerConfigImpl.getInstance().getIsDebugLogs()) {
-	            	Logger.getInstance().error(configResults.getErr());
-	            }
+        		
+        		Logger.getInstance().debug(configResults.getErr());
 	        } catch (Exception e) {
 	            CliDriverWrapper.getInstance().showCliError("An error occurred while setting up the server connection:", e);
 	        }

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/XrayGlobalConfiguration.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/configuration/XrayGlobalConfiguration.java
@@ -81,8 +81,9 @@ public class XrayGlobalConfiguration extends FieldEditorPreferencePage implement
 	                CliDriverWrapper.HOME_PATH.toFile(),
 	                configEnv
 	            );
-	            if (!configResults.getErr().isBlank()) {
-	            	throw new Exception(configResults.getErr());
+        		// log an error in case that the config command returned output not in debug log level
+	            if (!configResults.getErr().isBlank() && !XrayServerConfigImpl.getInstance().getIsDebugLogs()) {
+	            	Logger.getInstance().error(configResults.getErr());
 	            }
 	        } catch (Exception e) {
 	            CliDriverWrapper.getInstance().showCliError("An error occurred while setting up the server connection:", e);

--- a/bundle/src/main/java/com/jfrog/ide/eclipse/scan/ScanManager.java
+++ b/bundle/src/main/java/com/jfrog/ide/eclipse/scan/ScanManager.java
@@ -189,7 +189,7 @@ public class ScanManager {
 			} catch (CancellationException ce) {
 				log.info(ce.getMessage());
 			} catch (Exception e) {
-				CliDriverWrapper.getInstance().showCliError("An error occurred while performing audit scan", e);
+				log.error("An error occurred while performing audit scan", e);
 			} finally {
 				scanFinished();
 			}


### PR DESCRIPTION
- Fixed false error message that popped when configuring cli server.
- Upgrade plugins common to 2.4.4. 
- Changed the error show in cli commands that fail - logging to problems view instead of popping an error message window.